### PR TITLE
Bump tested-up-to values to WordPress 6.7 and WooCommerce 9.3.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,11 @@ add_filter( 'woocommerce_custom_product_tabs_lite_title', 'sv_change_custom_tab_
 
 == Changelog ==
 
+= 2024.nn.nn - version 1.9.0-dev.1 =
+* Fix - Ensure PHP 8.2+ compatibility
+* Misc - Declare WordPress 6.7
+* Misc -  Declare WooCommerce 9.3.3 compatibility
+
 = 2023.07.28 - version 1.8.0 =
  * Misc - Add compatibility for WooCommerce High Performance Order Storage (HPOS)
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: skyverge, maxrice, tamarazuk, chasewiseman, nekojira, beka.rice
 Tags: woocommerce, product tabs, custom tab, woo commerce tab
 Requires at least: 5.6
 Requires PHP: 7.4
-Tested up to: 6.2.2
+Tested up to: 6.7
 Stable tag: 1.9.0-dev.1
 
 This plugin extends WooCommerce by allowing a custom product tab to be created with any content.

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -20,7 +20,7 @@
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.9.4
- * WC tested up to: 7.9.0
+ * WC tested up to: 9.3.3
  */
 
 defined( 'ABSPATH' ) or exit;

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -302,7 +302,7 @@ class WooCommerceCustomProductTabsLite {
 
 			if ( $tab_title ) {
 
-				if ( strlen( $tab_title ) !== strlen( utf8_encode( $tab_title ) ) ) {
+				if ( strlen( $tab_title ) !== strlen( mb_convert_encoding( $tab_title, 'UTF-8', mb_detect_encoding( $tab_title ) ) ) ) {
 
 					// can't have titles with utf8 characters as it breaks the tab-switching javascript
 					$tab_id = "tab-custom";


### PR DESCRIPTION
Tested on:
- WordPress 6.7-RC1
- WooCommerce 9.3.3

Also applied a fix to avoid a deprecation notice related to usage of `utf8_encode()` in PHP 8.2+