### PR TITLE
Standardize product tabs meta storage

### DIFF
--- a/includes/Helpers/ProductTabsMetaHandler.php
+++ b/includes/Helpers/ProductTabsMetaHandler.php
@@ -45,7 +45,7 @@ class ProductTabsMetaHandler
 	 */
 	public function updateMeta(WC_Product &$product, array|string $meta) : void
 	{
-		$product->update_meta_data(static::PRODUCT_TABS_META_KEY, json_encode([$meta]));
+		$product->update_meta_data(static::PRODUCT_TABS_META_KEY, json_encode($meta));
 	}
 
 	/**
@@ -98,7 +98,7 @@ class ProductTabsMetaHandler
 	{
 		if ($meta = $this->getLegacyMeta($product)) {
 			$this->deleteLegacyMeta($product);
-			$this->updateMeta($product, $meta[0]);
+			$this->updateMeta($product, $meta);
 
 			$product->save();
 
@@ -111,21 +111,21 @@ class ProductTabsMetaHandler
 	/**
 	 * (Maybe) converts legacy product tabs meta to new meta.
 	 *
-	 * @param null $shortCircutValue The short-circuit meta value. Defualt null affects nothing.
+	 * @param null $shortCircuitValue The short-circuit meta value. Default null affects nothing.
 	 * @param int $objectId Object ID.
 	 * @param string $metaKey Meta key.
 	 * @param bool $single Whether to return only the first value.
 	 * @param string $metaType Meta type.
 	 * @return mixed
 	 */
-	public function maybeConvertLegacyProductTabsMeta($shortCircutValue, $objectId, $metaKey, $single, $metaType)
+	public function maybeConvertLegacyProductTabsMeta($shortCircuitValue, $objectId, $metaKey, $single, $metaType)
 	{
 		if (static::LEGACY_PRODUCT_TABS_META_KEY !== $metaKey) {
-			return $shortCircutValue;
+			return $shortCircuitValue;
 		}
 
 		if (! $product = wc_get_product($objectId)) {
-			return $shortCircutValue;
+			return $shortCircuitValue;
 		}
 
 		if($migrated = $this->maybeMigrateLegacyMeta($product)) {
@@ -134,7 +134,10 @@ class ProductTabsMetaHandler
 			$meta = $this->getMeta($product);
 		}
 
-		// Array-wrapped for back-compat. updateMeta() handles this for saves.
+		/**
+		 * The filter expects the content to be in an extra array, and {@see get_metadata_raw()} will handle pulling
+		 * out the first value for us.
+		 */
 		return [$meta];
 	}
 }

--- a/woocommerce-custom-product-tabs-lite.php
+++ b/woocommerce-custom-product-tabs-lite.php
@@ -353,11 +353,13 @@ class WooCommerceCustomProductTabsLite {
 				}
 			}
 
-			$tab_data = array(
-				'title'   => $tab_title,
-				'id'      => $tab_id,
-				'content' => $tab_content,
-			);
+			$tab_data = [
+				[
+					'title'   => $tab_title,
+					'id'      => $tab_id,
+					'content' => $tab_content,
+				]
+			];
 
 			$this->productTabsMetaHandler->updateMeta($product, $tab_data);
 			$product->save();


### PR DESCRIPTION
## Issue: [MWC-17827](https://godaddy-corp.atlassian.net/browse/MWC-17827)

## Details

Standardizes how we store product tabs meta to a model that uses JSON encoding. This approach means we can avoid many of the pitfalls that come along with having to wrangle serialized array data in meta.

- Seamlessly deprecates the `frs_woo_product_tabs` meta field in favor of a new `_wc_custom_product_tabs_lite_product_tabs` field.
- Calls to `get_post_meta(ID, 'frs_woo_product_tabs')` are set up to automatically migrate the meta from field to field via a filter callback on `get_post_metadata`.
- The compatibility layer for the legacy meta field may be removed in the future.

## QA

### Setup

1. Install Custom Product Tabs Lite for WooCommerce
2. On the `master` branch, update at least one product to set a custom tab title and tab contents to whatever you like

### Steps

#### Meta Migration
1. On the `master` branch, update at least one product to set a custom tab title and tab contents to whatever you like
    - [x] The custom tab saved successfully
    - [x] The custom tab contents display on the front end as expected
2. Compat – On `master` branch, manually run `var_dump(get_post_meta(ID, 'frs_woo_product_tabs', true));` against the meta, substituting the post ID for the product.
    - [x] The tab data array is output wrapped in an array. Note this for later steps.
4. Compat – On the `mwc-17827` branch, navigate to the edit screen for the product you just updated
    - [x] The custom tab title and contents are displayed in wp-admin exactly as before
    - [x] The custom tab title and contents are displayed on the frontend exactly as before
5. Compat – Still on the `mwc-17827` branch, run `var_dump(get_post_meta(ID, 'frs_woo_product_tabs', true));` again on the same product.
    - [x] Output format has not changed
6. Compat – In `includes/Helpers/ProductTabsMetaHandler.php`, temporarily comment out the `add_filter()` call inside the `addHooks()` method. Repeat the instructions in Step 5.
    - [x] An empty string is output instead of the tab data array.

#### New Saves

1. On the `mwc-17827` branch, update a separate, second product to set a custom tab title and tab contents
2. Save the product
    - [x] The custom tab saved successfully
    - [x] The custom tab contents display on the front end as expected
3. Compat – Still on the `mwc-17827` branch, run `var_dump(get_post_meta(ID, 'frs_woo_product_tabs', true));` substituting for the new product's post ID.
    - [x] The tab data array is output wrapped in an array
 4. Compat – In `includes/Helpers/ProductTabsMetaHandler.php`, temporarily comment out the `add_filter()` call inside the `addHooks()` method. Repeat the instructions in Step 3.
    - [x] An empty string is output instead of the tab data array.